### PR TITLE
create a pipelines table in dynamodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
 # Dynamic DynamoDB
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][wercker-image]][wercker-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
-> Create Screwdriver datastore tables in DynamoDB
+> A utility CLI for creating Screwdriver datastore tables in DynamoDB
 
 ## Usage
 
+### Installation
+
 ```bash
-npm install screwdriver-dynamic-dynamodb
+$ npm install -g screwdriver-dynamic-dynamodb
+```
+
+### API
+
+***Pipelines***
+
+```bash
+# Creates a pipelines DynamoDB table
+$ tables pipelines
+
+# Creates a pipelines DynamoDB table in Ireland
+$ tables pipelines --region eu-west-1
 ```
 
 ## Testing

--- a/bin/tables.js
+++ b/bin/tables.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+const Bobby = require('../lib/bobby');
+const commander = require('commander');
+const pkg = require('../package.json');
+
+commander.version(pkg.version);
+
+commander
+    .option('-r, --region <region>', 'AWS region to set up the table in');
+
+commander
+    .command('pipelines')
+    .description('Create a new pipeline table')
+    .action(() => {
+        const options = {
+            region: commander.region || 'us-west-2'
+        };
+        const client = new Bobby(options);
+
+        client.createPipelinesTable((err) => {
+            console.error(err);
+        });
+    });
+
+commander.parse(process.argv);
+
+if (!process.argv.slice(2).length) {
+    commander.help();
+}

--- a/config/pipeline.js
+++ b/config/pipeline.js
@@ -1,0 +1,45 @@
+'use strict';
+module.exports = {
+    AttributeDefinitions: [ /* required */
+        {
+            AttributeName: 'id', /* required */
+            AttributeType: 'S' /* required */
+        },
+        {
+            AttributeName: 'scmUrl', /* required */
+            AttributeType: 'S' /* required */
+        }
+    ],
+    KeySchema: [ /* required */
+        {
+            AttributeName: 'id', /* required */
+            KeyType: 'HASH' /* required */
+        }
+    ],
+    ProvisionedThroughput: { /* required */
+        ReadCapacityUnits: 1, /* required */
+        WriteCapacityUnits: 1 /* required */
+    },
+    TableName: 'Pipelines', /* required */
+    GlobalSecondaryIndexes: [
+        {
+            IndexName: 'ScmUrls', /* required */
+            KeySchema: [ /* required */
+                {
+                    AttributeName: 'scmUrl',
+                    KeyType: 'HASH'
+                }
+            ],
+            Projection: { /* required */
+                ProjectionType: 'KEYS_ONLY'
+            },
+            ProvisionedThroughput: {
+                ReadCapacityUnits: 1, /* required */
+                WriteCapacityUnits: 1 /* required */
+            }
+        }
+    ],
+    StreamSpecification: {
+        StreamEnabled: false
+    }
+};

--- a/lib/bobby.js
+++ b/lib/bobby.js
@@ -1,0 +1,29 @@
+'use strict';
+const AWS = require('aws-sdk');
+const CONFIGS = {
+    pipelines: require('../config/pipeline') // eslint-disable-line global-require
+};
+
+class Bobby {
+    /**
+     * Wrapper class to streamline interaction with AWS services for
+     * creating Screwdriver tables in DynamoDB
+     * @param  {String} region AWS region to interact with
+     */
+    constructor(region) {
+        this.region = region || 'us-west-2';
+        this.client = new AWS.DynamoDB({
+            region: this.region
+        });
+    }
+
+    /**
+     * Create a DynamoDB table for pipelines
+     * @param  {Function} callback fn(err)
+     */
+    createPipelinesTable(callback) {
+        this.client.createTable(CONFIGS.pipelines, callback);
+    }
+}
+
+module.exports = Bobby;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
+    "tables": "./bin/tables.js",
     "test": "jenkins-mocha --recursive"
   },
   "repository": {
@@ -35,7 +36,12 @@
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",
-    "jenkins-mocha": "^2.6.0"
+    "jenkins-mocha": "^2.6.0",
+    "mockery": "^1.7.0",
+    "sinon": "^1.17.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "aws-sdk": "^2.4.8",
+    "commander": "^2.9.0"
+  }
 }

--- a/test/bobby.test.js
+++ b/test/bobby.test.js
@@ -1,0 +1,81 @@
+'use strict';
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Bobby', () => {
+    let dynamoMock;
+    let dynamoConstructor;
+    let Bobby;
+    let pipelineConfigMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        dynamoMock = {
+            createTable: sinon.stub()
+        };
+        dynamoConstructor = sinon.stub();
+        dynamoConstructor.prototype = dynamoMock;
+        mockery.registerMock('aws-sdk', {
+            DynamoDB: dynamoConstructor
+        });
+
+        pipelineConfigMock = { config: 'pipeline' };
+        mockery.registerMock('../config/pipeline', pipelineConfigMock);
+
+        Bobby = require('../lib/bobby.js'); // eslint-disable-line global-require
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('loaded the sdk correctly', () => {
+        const client = new Bobby();
+
+        assert.isOk(client);
+        assert.calledWith(dynamoConstructor, {
+            region: 'us-west-2'
+        });
+    });
+
+    describe('pipelines', () => {
+        let client;
+
+        beforeEach(() => {
+            dynamoMock.createTable.yieldsAsync();
+
+            client = new Bobby();
+        });
+
+        it('can create a pipeline table', (done) => {
+            client.createPipelinesTable(() => {
+                assert.calledWith(dynamoMock.createTable, pipelineConfigMock);
+                done();
+            });
+        });
+
+        it('passes back the error encountered', (done) => {
+            const expectedErr = new Error('testError');
+
+            dynamoMock.createTable.yieldsAsync(expectedErr);
+            client.createPipelinesTable((err) => {
+                assert.strictEqual(expectedErr.message, err.message);
+                done();
+            });
+        });
+    });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,0 @@
-'use strict';
-const assert = require('chai').assert;
-
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
-    });
-});


### PR DESCRIPTION
Initial PoC of creating a pipelines table in DynamoDB. 

What this PR does and does _not_ accomplish:
:white_check_mark:  create pipelines table
:negative_squared_cross_mark: document usability
:negative_squared_cross_mark:  define the final end-user module
