### PR TITLE
Create all the tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ $ npm install -g screwdriver-dynamic-dynamodb
 
 ### API
 
-***Pipelines***
-
 ```bash
-# Creates a pipelines DynamoDB table
-$ tables pipelines
+# Creates all DynamoDB tables
+$ screwdriver-db-setup
 
-# Creates a pipelines DynamoDB table in Ireland
-$ tables pipelines --region eu-west-1
+# Creates all DynamoDB tables in Ireland
+$ screwdriver-db-setup --region eu-west-1
 ```
 
 ## Testing

--- a/bin/tables.js
+++ b/bin/tables.js
@@ -1,31 +1,25 @@
 #!/usr/bin/env node
 'use strict';
+
 const Bobby = require('../lib/bobby');
 const commander = require('commander');
 const pkg = require('../package.json');
+const winston = require('winston');
 
 commander.version(pkg.version);
-
 commander
-    .option('-r, --region <region>', 'AWS region to set up the table in');
-
-commander
-    .command('pipelines')
-    .description('Create a new pipeline table')
-    .action(() => {
-        const options = {
-            region: commander.region || 'us-west-2'
-        };
-        const client = new Bobby(options);
-
-        client.setupPipelinesTable();
-        client.createTables((err) => {
-            console.error(err);
-        });
-    });
-
+    .option('-r, --region <region>', 'AWS region to set up the tables in');
 commander.parse(process.argv);
 
-if (!process.argv.slice(2).length) {
-    commander.help();
-}
+const client = new Bobby({
+    region: commander.region || 'us-west-2'
+});
+
+client.setupTables();
+client.createTables((err) => {
+    if (err) {
+        winston.error(err);
+        process.exit(1);
+    }
+    winston.info('Tables created!');
+});

--- a/lib/bobby.js
+++ b/lib/bobby.js
@@ -16,27 +16,27 @@ class Bobby {
     }
 
     /**
-     * Setup pipeline model for creation
+     * Setup all models for creation
      */
-    setupPipelinesTable() {
-        const modelName = 'pipeline';
-        const pipelineSchema = dataSchema[modelName];
-        const hashKey = pipelineSchema.hashKey || 'id';
-        const schema = pipelineSchema.base;
-        const tableName = pipelineSchema.tableName || 'pipelines';
-        const vogelsObject = {
-            hashKey,
-            schema,
-            tableName,
-            indexes: [{
-                hashKey: 'scmUrl',
-                name: 'ScmUrlIndex',
+    setupTables() {
+        ['build', 'job', 'pipeline', 'platform', 'user'].forEach((modelName) => {
+            const schema = dataSchema[modelName];
+            const indexes = schema.indexes.map((key) => ({
+                hashKey: key,
+                name: `${key}Index`,
                 type: 'global',
                 projection: { ProjectionType: 'KEYS_ONLY' }
-            }]
-        };
+            }));
 
-        vogels.define(modelName, vogelsObject);
+            const vogelsObject = {
+                hashKey: 'id',
+                schema: schema.base,
+                tableName: schema.tableName,
+                indexes
+            };
+
+            vogels.define(modelName, vogelsObject);
+        });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "screwdriver-dynamic-dynamodb",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Create Screwdriver datastore tables in DynamoDB",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "tables": "./bin/tables.js",
     "test": "jenkins-mocha --recursive"
+  },
+  "bin": {
+    "screwdriver-db-setup": "./bin/tables.js"
   },
   "repository": {
     "type": "git",
@@ -43,6 +45,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "screwdriver-data-schema": "^4.0.0",
-    "vogels": "^2.2.0"
+    "vogels": "^2.2.0",
+    "winston": "^2.2.0"
   }
 }

--- a/test/bobby.test.js
+++ b/test/bobby.test.js
@@ -91,13 +91,96 @@ describe('Bobby', () => {
             client = new Bobby();
         });
 
-        it('defines model with correct default values', () => {
+        it('defines model with correct values', () => {
+            dataSchemaMock.build = {
+                base: {
+                    bar: 'joi.bar()'
+                },
+                tableName: 'builds',
+                indexes: ['bar']
+            };
+            dataSchemaMock.job = {
+                base: {
+                    baz: 'joi.bar()'
+                },
+                tableName: 'jobs',
+                indexes: ['baz']
+            };
+            dataSchemaMock.platform = {
+                base: {
+                    bin: 'joi.bar()'
+                },
+                tableName: 'platforms',
+                indexes: ['bin']
+            };
+            dataSchemaMock.user = {
+                base: {
+                    min: 'joi.bar()'
+                },
+                tableName: 'users',
+                indexes: ['min']
+            };
             dataSchemaMock.pipeline = {
                 base: {
                     foo: 'joi.bar()'
-                }
+                },
+                tableName: 'pipelines',
+                indexes: ['foo']
             };
-            client.setupPipelinesTable();
+            client.setupTables();
+
+            assert.calledWith(vogelsMock.define, 'build', {
+                hashKey: 'id',
+                schema: {
+                    bar: 'joi.bar()'
+                },
+                tableName: 'builds',
+                indexes: [{
+                    hashKey: 'bar',
+                    name: 'barIndex',
+                    type: 'global',
+                    projection: { ProjectionType: 'KEYS_ONLY' }
+                }]
+            });
+            assert.calledWith(vogelsMock.define, 'job', {
+                hashKey: 'id',
+                schema: {
+                    baz: 'joi.bar()'
+                },
+                tableName: 'jobs',
+                indexes: [{
+                    hashKey: 'baz',
+                    name: 'bazIndex',
+                    type: 'global',
+                    projection: { ProjectionType: 'KEYS_ONLY' }
+                }]
+            });
+            assert.calledWith(vogelsMock.define, 'platform', {
+                hashKey: 'id',
+                schema: {
+                    bin: 'joi.bar()'
+                },
+                tableName: 'platforms',
+                indexes: [{
+                    hashKey: 'bin',
+                    name: 'binIndex',
+                    type: 'global',
+                    projection: { ProjectionType: 'KEYS_ONLY' }
+                }]
+            });
+            assert.calledWith(vogelsMock.define, 'user', {
+                hashKey: 'id',
+                schema: {
+                    min: 'joi.bar()'
+                },
+                tableName: 'users',
+                indexes: [{
+                    hashKey: 'min',
+                    name: 'minIndex',
+                    type: 'global',
+                    projection: { ProjectionType: 'KEYS_ONLY' }
+                }]
+            });
             assert.calledWith(vogelsMock.define, 'pipeline', {
                 hashKey: 'id',
                 schema: {
@@ -105,33 +188,21 @@ describe('Bobby', () => {
                 },
                 tableName: 'pipelines',
                 indexes: [{
-                    hashKey: 'scmUrl',
-                    name: 'ScmUrlIndex',
+                    hashKey: 'foo',
+                    name: 'fooIndex',
                     type: 'global',
                     projection: { ProjectionType: 'KEYS_ONLY' }
                 }]
             });
-        });
-
-        it('defines model with values from data schema', () => {
-            dataSchemaMock.pipeline = {
-                base: {
-                    foo: 'joi.bar()'
-                },
-                hashKey: 'hashKey',
-                tableName: 'pipelineTable'
-            };
-            client.setupPipelinesTable();
             assert.calledWith(vogelsMock.define, 'pipeline', {
-                hashKey: 'hashKey',
+                hashKey: 'id',
                 schema: {
                     foo: 'joi.bar()'
                 },
-
-                tableName: 'pipelineTable',
+                tableName: 'pipelines',
                 indexes: [{
-                    hashKey: 'scmUrl',
-                    name: 'ScmUrlIndex',
+                    hashKey: 'foo',
+                    name: 'fooIndex',
                     type: 'global',
                     projection: { ProjectionType: 'KEYS_ONLY' }
                 }]


### PR DESCRIPTION
Now the command-line tool will create all the tables :)

```
$ screwdriver-db-setup --help

  Usage: screwdriver-db-setup [options]

  Options:

    -h, --help             output usage information
    -V, --version          output the version number
    -r, --region <region>  AWS region to set up the tables in

$ screwdriver-db-setup
info: Tables created!
```
