### PR TITLE
Update ESLint to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,9 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^2.10.2",
-    "eslint-config-screwdriver": "^1.0.0",
-    "eslint-plugin-import": "^1.8.0",
-    "eslint-plugin-jsx-a11y": "^1.2.2",
-    "eslint-plugin-react": "^5.1.1",
+    "eslint": "^3.2.2",
+    "eslint-config-screwdriver": "^2.0.0",
+    "eslint-plugin-import": "^1.12.0",
     "jenkins-mocha": "^2.6.0",
     "mockery": "^1.7.0",
     "sinon": "^1.17.4"


### PR DESCRIPTION
Update to latest version of ESLint and our lint ruleset. Remove unnecessary peer dependencies.
