### PR TITLE
Apply list of rangeKeys with associated indices

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,12 @@ class Bobby {
             indexes
         };
 
-        if (schema.rangeKey) {
-            vogelsObject.rangeKey = schema.rangeKey;
+        if (Array.isArray(schema.rangeKeys)) {
+            schema.rangeKeys.forEach((rangeKey, indexNumber) => {
+                if (rangeKey) {
+                    indexes[indexNumber].rangeKey = rangeKey;
+                }
+            });
         }
 
         return vogels.define(modelName, vogelsObject);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-dynamic-dynamodb",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Create Screwdriver datastore tables in DynamoDB",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,12 +24,18 @@ describe('Bobby', () => {
                     base: 'baseSchema',
                     tableName: 'buildTableName',
                     indexes: ['first', 'second'],
-                    rangeKey: 'second'
+                    rangeKeys: [null, 'otherColumn']
                 },
                 job: {
                     base: 'baseSchema',
                     tableName: 'jobTableName',
                     indexes: ['foo', 'bar']
+                },
+                pipeline: {
+                    base: 'baseSchema',
+                    tableName: 'pipelineTableName',
+                    rangeKeys: 'invalidRangeKeyValue',
+                    indexes: ['gummyBear']
                 }
             }
         };
@@ -127,7 +133,6 @@ describe('Bobby', () => {
 
             assert.calledWith(vogelsMock.define, 'build', {
                 hashKey: 'id',
-                rangeKey: 'second',
                 schema: 'baseSchema',
                 tableName: 'buildTableName',
                 indexes: [
@@ -138,7 +143,25 @@ describe('Bobby', () => {
                     },
                     {
                         hashKey: 'second',
+                        rangeKey: 'otherColumn',
                         name: 'secondIndex',
+                        type: 'global'
+                    }
+                ]
+            });
+        });
+
+        it('ignores incorrect definitions of range keys', () => {
+            client.defineTable('pipeline');
+
+            assert.calledWith(vogelsMock.define, 'pipeline', {
+                hashKey: 'id',
+                schema: 'baseSchema',
+                tableName: 'pipelineTableName',
+                indexes: [
+                    {
+                        hashKey: 'gummyBear',
+                        name: 'gummyBearIndex',
                         type: 'global'
                     }
                 ]


### PR DESCRIPTION
This PR maps a list of `rangeKey` with the index that it aligns with. Defining a `rangeKey` will allow us to use an _order_ operation when performing a DynamoDB query.
